### PR TITLE
【個人開発12】項目編集機能実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/SkillEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillEditController.java
@@ -2,11 +2,14 @@ package com.spring.springbootapplication.controller;
 
 import com.spring.springbootapplication.dto.LearningDataDto;
 import com.spring.springbootapplication.dto.LearningEditForm;
+import com.spring.springbootapplication.dto.LearningTimeUpdateRequest;
 import com.spring.springbootapplication.entity.LearningData;
 import com.spring.springbootapplication.service.LearningDataService;
 import com.spring.springbootapplication.service.UserService;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -28,36 +31,30 @@ public class SkillEditController {
 
     @GetMapping("/learning/edit")
     public String showEditPage(@RequestParam(name = "month", required = false) String month,
-                            Model model, Principal principal) {
+            Model model, Principal principal) {
         Integer userId = userService.findByEmail(principal.getName()).getId();
-    
+
         YearMonth targetMonth = (month != null) ? YearMonth.parse(month) : YearMonth.now();
         LocalDate firstDayOfMonth = targetMonth.atDay(1);
-        
+
         List<LearningDataDto> backendList = convertToDtoList(
-            learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 1)
-        );
+                learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 1));
         List<LearningDataDto> frontendList = convertToDtoList(
-            learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 2)
-        );
+                learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 2));
         List<LearningDataDto> infraList = convertToDtoList(
-            learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 3)
-        );
-    
+                learningDataService.getByUserIdMonthAndCategory(userId, firstDayOfMonth, 3));
+
         model.addAttribute("form", new LearningEditForm(backendList, frontendList, infraList, targetMonth));
-        model.addAttribute("frontendList", frontendList);
-        model.addAttribute("infraList", infraList);
-        model.addAttribute("selectableMonths", getLastThreeMonths()); 
+        model.addAttribute("selectableMonths", getLastThreeMonths());
         model.addAttribute("targetMonth", targetMonth.toString());
-    
+
         return "skillEdit";
     }
-    
+
     @PostMapping("/learning/edit")
     public String updateLearningData(
             @ModelAttribute("form") LearningEditForm form,
-            RedirectAttributes redirectAttributes
-    ) {
+            RedirectAttributes redirectAttributes) {
         learningDataService.updateLearningData(form.getBackendList());
         redirectAttributes.addAttribute("month", form.getTargetMonth().toString());
         return "redirect:/learning/edit";
@@ -68,10 +65,14 @@ public class SkillEditController {
             LearningDataDto dto = new LearningDataDto();
             dto.setId(entity.getId());
             dto.setLearningName(entity.getLearningName());
-            dto.setLearningTime(entity.getLearningTime());
+    
+            int time = entity.getLearningTime(); //0を1に補正
+            dto.setLearningTime(time == 0 ? 1 : time);
+    
             return dto;
         }).collect(Collectors.toList());
     }
+    
 
     private List<YearMonth> getLastThreeMonths() {
         YearMonth now = YearMonth.now();
@@ -79,4 +80,12 @@ public class SkillEditController {
                 .mapToObj(i -> now.minusMonths(i))
                 .collect(Collectors.toList());
     }
+
+    @PostMapping("/learning/update")
+    @ResponseBody
+    public ResponseEntity<Void> updateLearningTime(@RequestBody LearningTimeUpdateRequest request) {
+        learningDataService.updateLearningTime(request.getId(), request.getLearningTime());
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/spring/springbootapplication/dto/DeleteLearningRequest.java
+++ b/src/main/java/com/spring/springbootapplication/dto/DeleteLearningRequest.java
@@ -1,0 +1,8 @@
+package com.spring.springbootapplication.dto;
+
+import lombok.Data;
+
+@Data
+public class DeleteLearningRequest {
+    private Integer id;
+}

--- a/src/main/java/com/spring/springbootapplication/dto/LearningTimeUpdateRequest.java
+++ b/src/main/java/com/spring/springbootapplication/dto/LearningTimeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.spring.springbootapplication.dto;
+
+import lombok.Data;
+
+@Data
+public class LearningTimeUpdateRequest {
+    private Integer id;
+    private Integer learningTime;
+}

--- a/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
+++ b/src/main/java/com/spring/springbootapplication/repository/LearningDataRepository.java
@@ -10,8 +10,9 @@ import java.util.List;
 @Repository
 public interface LearningDataRepository extends JpaRepository<LearningData, Integer> {
 
-    List<LearningData> findByUserIdAndLearningMonth(Integer userId, LocalDate learningMonth);
-
+    List<LearningData> findByUserIdAndLearningMonthAndCategoryIdOrderByIdAsc(
+        Integer userId, LocalDate learningMonth, Integer categoryId);
+    
     List<LearningData> findByUserIdAndLearningMonthAndCategoryId(Integer userId, LocalDate learningMonth, Integer categoryId);
 
     boolean existsByUserIdAndLearningMonthAndLearningName(Integer userId, LocalDate learningMonth, String learningName);

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -15,13 +15,14 @@ public class LearningDataService {
 
     private final LearningDataRepository learningDataRepository;
 
-    public List<LearningData> getByUserIdAndMonth(Integer userId, LocalDate month) {
-        return learningDataRepository.findByUserIdAndLearningMonth(userId, month);
-    }
-
     public List<LearningData> getByUserIdMonthAndCategory(Integer userId, LocalDate month, Integer categoryId) {
-        return learningDataRepository.findByUserIdAndLearningMonthAndCategoryId(userId, month, categoryId);
+        return learningDataRepository.findByUserIdAndLearningMonthAndCategoryIdOrderByIdAsc(userId, month, categoryId);
     }
+    
+
+    // public List<LearningData> getByUserIdMonthAndCategory(Integer userId, LocalDate month, Integer categoryId) {
+    //     return learningDataRepository.findByUserIdAndLearningMonthAndCategoryId(userId, month, categoryId);
+    // }
 
     public void updateLearningData(List<LearningDataDto> dtoList) {
         for (LearningDataDto dto : dtoList) {

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -40,4 +40,10 @@ public class LearningDataService {
         return learningDataRepository.existsByUserIdAndLearningMonthAndLearningName(userId, month, name);
     }
     
+    public void updateLearningTime(Integer id, Integer learningTime) {
+        LearningData data = learningDataRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("対象の学習データが見つかりません"));
+        data.setLearningTime(learningTime);
+        learningDataRepository.save(data);
+    }
 }

--- a/src/main/resources/static/css/modal/modalBase.css
+++ b/src/main/resources/static/css/modal/modalBase.css
@@ -25,23 +25,9 @@
   align-items: center;
 }
 
-.modal-message {
-  font-family: 'Roboto', sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-  color: #000;
-  line-height: 28px;
-  margin-bottom: 40px;
-  white-space: pre-line;
-}
-
-.modal-message span {
-  margin-bottom: 10px;
-}
-
 .custom-button {
   width: 192px;
-  height: 48px;
+  height: 48px !important;
   background-color: #1B5678;
   color: #fff;
   font-family: 'Roboto', sans-serif;
@@ -51,7 +37,6 @@
   border-radius: 4px;
   text-align: center;
   cursor: pointer;
-  margin-bottom: 50px;
 }
 
 .custom-button:hover {

--- a/src/main/resources/static/css/modal/modalBase.css
+++ b/src/main/resources/static/css/modal/modalBase.css
@@ -9,7 +9,7 @@
   height: 240px;
   border-radius: 0;
   background-color: #fff;
-  border: 2px solid #1B5678;
+  border: 2px solid #fff;
   box-shadow: none;
   text-align: center;
   padding: 0;

--- a/src/main/resources/static/css/modal/modalEdit.css
+++ b/src/main/resources/static/css/modal/modalEdit.css
@@ -1,0 +1,49 @@
+.custom-modal-content {
+  width: 640px;
+  height: 240px;
+  padding: 0;
+  border: 2px solid #1B5678;
+  background-color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-body {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: start;
+  box-sizing: border-box;
+}
+
+.modal-message {
+  margin-top: 65.5px;
+  margin-bottom: 40px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #000;
+  font-family: 'Roboto', sans-serif;
+  line-height: 28px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  white-space: pre-line;
+}
+
+.modal-message {
+  margin-top: 65.5px;
+  margin-bottom: 40px;
+  height: 56px;
+}
+
+.modal-button-wrapper {
+  margin-bottom: 65.5px;
+}
+

--- a/src/main/resources/static/css/modal/modalEdit.css
+++ b/src/main/resources/static/css/modal/modalEdit.css
@@ -2,7 +2,7 @@
   width: 640px;
   height: 240px;
   padding: 0;
-  border: 2px solid #1B5678;
+  border: 2px solid #fff;
   background-color: #fff;
   display: flex;
   align-items: center;

--- a/src/main/resources/static/css/modal/modalNew.css
+++ b/src/main/resources/static/css/modal/modalNew.css
@@ -1,0 +1,17 @@
+.modal-message {
+  font-family: 'Roboto', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: #000;
+  line-height: 28px;
+  margin-bottom: 40px;
+  white-space: pre-line;
+}
+
+.modal-message span {
+  margin-bottom: 10px;
+}
+
+.custom-button {
+margin-bottom: 50px;
+}

--- a/src/main/resources/static/css/skillEdit.css
+++ b/src/main/resources/static/css/skillEdit.css
@@ -7,7 +7,7 @@
     gap: 40px;
   }
 
-  .html, body {
+  html, body {
     margin: 0;
     padding: 0;
   }
@@ -197,27 +197,18 @@
     padding: 20px 16px 20px 26px;
   }
 
-  .card-row select.form-select {
-    width: 160px;
-    height: 40px;
-    padding: 0 40px 0 16px;
-    font-size: 14px;
-    line-height: 40px;
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    box-sizing: border-box;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background:
-      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='8' fill='black' viewBox='0 0 16 8'><path d='M4 6l4-4 4 4z'/></svg>") no-repeat right 12px top 10px,
-      url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='8' fill='black' viewBox='0 0 16 8'><path d='M4 2l4 4 4-4z'/></svg>") no-repeat right 12px bottom 10px;
-    background-size: 16px 8px;
-  }
+.error-message {
+  color: #EE6969;
+  font-size: 12px;
+  font-family: 'Roboto', sans-serif;
+  margin-top: 4px;
+  padding-left: 4px;
+}
+
 
   .cell.save-button {
     width: 200px;
-    padding: 20 16 20 26px;
+    padding: 20px 16px 20px 26px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -283,3 +274,9 @@
   .card-body.scrollable-table-wrapper::-webkit-scrollbar-thumb {
     border-radius: 4px;
   }   
+
+  input.learning-time-input {
+    font-family: sans-serif !important;
+    font-weight: 400 !important;
+  }
+  

--- a/src/main/resources/static/js/skillEdit.js
+++ b/src/main/resources/static/js/skillEdit.js
@@ -1,0 +1,74 @@
+// CSRFトークンを取得する関数
+function getCsrfToken() {
+  const token = document.querySelector('meta[name="_csrf"]');
+  return token ? token.getAttribute('content') : null;
+}
+
+function getCsrfHeader() {
+  const header = document.querySelector('meta[name="_csrf_header"]');
+  return header ? header.getAttribute('content') : 'X-CSRF-TOKEN';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const saveButtons = document.querySelectorAll('.btn-save');
+  saveButtons.forEach(btn => {
+    btn.addEventListener('click', async (e) => {
+      e.preventDefault();
+
+      const row = btn.closest('.card-row');
+      const id = row.querySelector('input[name$=".id"]').value;
+      const name = row.querySelector('input[name$=".learningName"]').value;
+      const timeInput = row.querySelector('input[name$=".learningTime"], select[name$=".learningTime"]');
+
+      const time = timeInput.value.trim();
+      const errorField = row.querySelector('.error-message');
+      if (errorField) errorField.textContent = ''; // エラー初期化
+
+      if (time === '') {
+        if (errorField) errorField.textContent = '学習時間は必ず入力してください';
+        return;
+      }
+
+      const parsed = parseInt(time);
+      if (!/^\d+$/.test(time) || isNaN(parsed) || parsed < 1) {
+        if (errorField) errorField.textContent = '1以上の数値を入力してください';
+        return;
+      }
+
+
+      try {
+        const csrfToken = getCsrfToken();
+        const csrfHeader = getCsrfHeader();
+
+        const headers = {
+          'Content-Type': 'application/json'
+        };
+        if (csrfToken) {
+          headers[csrfHeader] = csrfToken;
+        }
+
+        const response = await fetch('/learning/update', {
+          method: 'POST',
+          headers: headers,
+          body: JSON.stringify({ id: id, learningTime: time })
+        });
+
+        if (response.ok) {
+          document.getElementById('editItemName').textContent = name;
+          const modal = new bootstrap.Modal(document.getElementById('learningEditSuccessModal'));
+          modal.show();
+        } else {
+          alert('保存に失敗しました。');
+        }
+      } catch (error) {
+        console.error(error);
+        alert('通信エラーが発生しました。');
+      }
+    });
+  });
+
+  // モーダルから戻るボタン
+  document.getElementById('backToEditBtn').addEventListener('click', () => {
+    window.location.href = '/learning/edit';
+  });
+});

--- a/src/main/resources/templates/fragments/modal/modalDeleteSuccess.html
+++ b/src/main/resources/templates/fragments/modal/modalDeleteSuccess.html
@@ -1,0 +1,14 @@
+<div th:fragment="deleteSuccessModal">
+  <div class="modal fade" id="deleteSuccessModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content custom-modal-content">
+        <div class="modal-body text-center">
+          <p class="modal-message">
+            <span id="deletedItemName" class="bold-text"></span> を削除しました。
+          </p>
+          <button id="backToEditFromDelete" class="btn btn-primary custom-button">編集ページに戻る</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/fragments/modal/modalLearningEditSuccess.html
+++ b/src/main/resources/templates/fragments/modal/modalLearningEditSuccess.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+  <body>
+    <div th:fragment="successModal">
+      <div class="modal fade" id="learningEditSuccessModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content custom-modal-content">
+            <div class="modal-body text-center">
+              <p class="modal-message">
+                <span id="editItemName" class="bold-text"></span> の学習時間を保存しました！
+              </p>
+              <div class="modal-button-wrapper">
+              <button id="backToEditBtn" class="custom-button">編集ページに戻る</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/skillEdit.html
+++ b/src/main/resources/templates/skillEdit.html
@@ -3,9 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>学習編集</title>
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link rel="stylesheet" th:href="@{/css/style.css}">
     <link rel="stylesheet" th:href="@{/css/skillEdit.css}">
+    <link rel="stylesheet" th:href="@{/css/modal/modalBase.css}">
+    <link rel="stylesheet" th:href="@{/css/modal/modalEdit.css}">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -49,14 +53,16 @@
                         </div>
                         
                         <div class="cell time">
-                            <select class="form-select" th:field="*{backendList[__${stat.index}__].learningTime}">
-                                <option th:each="m : ${#numbers.sequence(0, 1440)}"
-                                        th:value="${m}" th:text="${m}"></option>
-                            </select>
+                            <input type="number" min="1" max="1440" value="1"
+                                class="form-control learning-time-input"
+                                th:field="*{backendList[__${stat.index}__].learningTime}" />
+                            <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
+                        
+                                                    
 
                         <div class="cell save-button">
-                            <button class="btn-save" type="submit">学習時間を保存する</button>
+                            <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
                         
                         <div class="cell delete-button">
@@ -89,21 +95,21 @@
                         </div>
                         
                         <div class="cell time">
-                            <select class="form-select" th:field="*{frontendList[__${stat.index}__].learningTime}">
-                                <option th:each="m : ${#numbers.sequence(0, 1440)}"
-                                        th:value="${m}" th:text="${m}"></option>
-                            </select>
+                            <input type="number" min="1" max="1440"
+                                class="form-control learning-time-input"
+                                th:field="*{frontendList[__${stat.index}__].learningTime}" />
+                            <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
 
                         <div class="cell save-button">
-                            <button class="btn-save" type="submit">学習時間を保存する</button>
+                            <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
 
                         <div class="cell delete-button">
                             <button class="btn-delete" type="button" onclick="alert('削除は未実装です')">削除する</button>
                         </div>
                     </div>
-                </div>
+                </div>  
             </div>
 
             <!-- インフラ -->
@@ -129,14 +135,14 @@
                         </div>
                         
                         <div class="cell time">
-                            <select class="form-select" th:field="*{infraList[__${stat.index}__].learningTime}">
-                                <option th:each="m : ${#numbers.sequence(0, 1440)}"
-                                        th:value="${m}" th:text="${m}"></option>
-                            </select>
+                            <input type="number" min="1" max="1440"
+                                class="form-control learning-time-input"
+                                th:field="*{infraList[__${stat.index}__].learningTime}" />
+                            <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
 
                         <div class="cell save-button">
-                            <button class="btn-save" type="submit">学習時間を保存する</button>
+                            <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
 
                         <div class="cell delete-button">
@@ -148,6 +154,10 @@
         </form>
     </main>
 
+    <div th:replace="fragments/modal/modalLearningEditSuccess :: successModal"></div>
     <div th:replace="~{fragments/footer :: footer}"></div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script th:src="@{/js/skillEdit.js}"></script>
+
 </body>
 </html>       

--- a/src/main/resources/templates/skillNew.html
+++ b/src/main/resources/templates/skillNew.html
@@ -6,7 +6,9 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" th:href="@{/css/style.css}">
   <link rel="stylesheet" th:href="@{/css/skillNew.css}">
-  <link rel="stylesheet" th:href="@{/css/modal.css}">
+  <link rel="stylesheet" th:href="@{/css/modal/modalBase.css}">
+  <link rel="stylesheet" th:href="@{/css/modal/modalNew.css}">
+
   <meta name="_csrf" th:content="${_csrf.token}" />
   <meta name="_csrf_header" th:content="${_csrf.headerName}" />
 </head>


### PR DESCRIPTION
## 概要

- 項目一覧画面にて学習時間を直接編集可能  
- 「学習時間を保存する」ボタン押下で更新処理を実行  
- 編集が成功すると完了モーダルを表示  
- モーダルの「編集ページに戻る」ボタンで一覧画面にリロード遷移  

## 実装内容

- `SkillEditController`, `LearningEditForm`, `LearningTimeUpdateRequest` の作成・更新処理実装  
- `learningDataService.updateLearningTime()` による1件ずつの更新処理を追加  
- `skillEdit.html` のUIを調整し、編集可能な `input type="number"` に統一  
- `skillEdit.js` にてクリック時の非同期送信・バリデーション・モーダル表示を実装  
- 0以下の数値をバリデーションで拒否、未入力時はエラーメッセージを表示  

## 動作確認

- 動作確認用のユーザー情報は Slack にてご共有します

### チケット
- [PRUM_ACADEMY-3614](https://prum.backlog.com/view/PRUM_ACADEMY-3614)

## 実装後の結果

- Slackにて動作確認動画を添付しますので、そちらをご参照ください。