### PR TITLE
【個人開発13】項目削除機能実装

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/SkillEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillEditController.java
@@ -6,6 +6,8 @@ import com.spring.springbootapplication.dto.LearningTimeUpdateRequest;
 import com.spring.springbootapplication.entity.LearningData;
 import com.spring.springbootapplication.service.LearningDataService;
 import com.spring.springbootapplication.service.UserService;
+import com.spring.springbootapplication.dto.DeleteLearningRequest;
+
 
 import lombok.RequiredArgsConstructor;
 
@@ -87,5 +89,13 @@ public class SkillEditController {
         learningDataService.updateLearningTime(request.getId(), request.getLearningTime());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/learning/delete")
+@ResponseBody
+public ResponseEntity<Void> deleteLearningData(@RequestBody DeleteLearningRequest request) {
+    learningDataService.deleteLearningData(request.getId());
+    return ResponseEntity.ok().build();
+}
+
 
 }

--- a/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
+++ b/src/main/java/com/spring/springbootapplication/service/LearningDataService.java
@@ -47,4 +47,9 @@ public class LearningDataService {
         data.setLearningTime(learningTime);
         learningDataRepository.save(data);
     }
+    
+    public void deleteLearningData(Integer id) {
+        learningDataRepository.deleteById(id);
+    }
+    
 }

--- a/src/main/resources/static/css/modal/modalBase.css
+++ b/src/main/resources/static/css/modal/modalBase.css
@@ -1,3 +1,5 @@
+
+/* modalBase.css */
 .modal-dialog {
   max-width: unset;
   width: 640px;

--- a/src/main/resources/static/css/modal/modalEdit.css
+++ b/src/main/resources/static/css/modal/modalEdit.css
@@ -35,15 +35,13 @@
   justify-content: center;
   text-align: center;
   white-space: pre-line;
+  margin: 65.5px 0 40px 0; /* 上下左右のmarginを明示的に指定 */
 }
 
-.modal-message {
-  margin-top: 65.5px;
-  margin-bottom: 40px;
-  height: 56px;
-}
-
-.modal-button-wrapper {
+/* ボタンの位置調整 - 下部に65.5pxの余白を確保 */
+#backToEditFromDelete {
   margin-bottom: 65.5px;
+  height: 48px !important;
+  line-height: normal !important;
+  min-height: 48px !important;
 }
-

--- a/src/main/resources/static/js/skillEdit.js
+++ b/src/main/resources/static/js/skillEdit.js
@@ -10,6 +10,7 @@ function getCsrfHeader() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  // 保存ボタン処理
   const saveButtons = document.querySelectorAll('.btn-save');
   saveButtons.forEach(btn => {
     btn.addEventListener('click', async (e) => {
@@ -19,7 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const id = row.querySelector('input[name$=".id"]').value;
       const name = row.querySelector('input[name$=".learningName"]').value;
       const timeInput = row.querySelector('input[name$=".learningTime"], select[name$=".learningTime"]');
-
       const time = timeInput.value.trim();
       const errorField = row.querySelector('.error-message');
       if (errorField) errorField.textContent = ''; // エラー初期化
@@ -34,7 +34,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (errorField) errorField.textContent = '1以上の数値を入力してください';
         return;
       }
-
 
       try {
         const csrfToken = getCsrfToken();
@@ -67,8 +66,58 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // モーダルから戻るボタン
-  document.getElementById('backToEditBtn').addEventListener('click', () => {
-    window.location.href = '/learning/edit';
+  // 削除ボタン処理（confirmなし）
+  const deleteButtons = document.querySelectorAll('.btn-delete');
+  deleteButtons.forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const row = btn.closest('.card-row');
+      const id = row.querySelector('input[name$=".id"]').value;
+      const name = row.querySelector('input[name$=".learningName"]').value;
+
+      try {
+        const csrfToken = getCsrfToken();
+        const csrfHeader = getCsrfHeader();
+
+        const headers = {
+          'Content-Type': 'application/json'
+        };
+        if (csrfToken) {
+          headers[csrfHeader] = csrfToken;
+        }
+
+        const response = await fetch('/learning/delete', {
+          method: 'POST',
+          headers: headers,
+          body: JSON.stringify({ id: id })
+        });
+
+        if (response.ok) {
+          document.getElementById('deletedItemName').textContent = name;
+          const modal = new bootstrap.Modal(document.getElementById('deleteSuccessModal'));
+          modal.show();
+        } else {
+          alert('削除に失敗しました。');
+        }
+      } catch (error) {
+        console.error(error);
+        alert('通信エラーが発生しました。');
+      }
+    });
   });
+
+  // モーダル「戻る」ボタンで編集画面に戻る（保存成功）
+  const backToEditBtn = document.getElementById('backToEditBtn');
+  if (backToEditBtn) {
+    backToEditBtn.addEventListener('click', () => {
+      window.location.href = '/learning/edit';
+    });
+  }
+
+  // モーダル「戻る」ボタンで編集画面に戻る（削除成功）
+  const backToEditFromDelete = document.getElementById('backToEditFromDelete');
+  if (backToEditFromDelete) {
+    backToEditFromDelete.addEventListener('click', () => {
+      window.location.href = '/learning/edit';
+    });
+  }
 });

--- a/src/main/resources/templates/fragments/modal/modalDeleteSuccess.html
+++ b/src/main/resources/templates/fragments/modal/modalDeleteSuccess.html
@@ -4,9 +4,9 @@
       <div class="modal-content custom-modal-content">
         <div class="modal-body text-center">
           <p class="modal-message">
-            <span id="deletedItemName" class="bold-text"></span> を削除しました。
+            <span id="deletedItemName" class="bold-text"></span> を削除しました!
           </p>
-          <button id="backToEditFromDelete" class="btn btn-primary custom-button">編集ページに戻る</button>
+          <button id="backToEditFromDelete" class="custom-button">編集ページに戻る</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/fragments/modal/modalSuccess.html
+++ b/src/main/resources/templates/fragments/modal/modalSuccess.html
@@ -7,7 +7,7 @@
             <span id="itemCategory" class="bold-text"></span> に <span id="itemName" class="bold-text"></span> を
             <span id="itemTime" class="bold-text"></span>で追加しました！
           </p>
-          <button id="backToEdit" class="btn btn-primary custom-button">編集ページに戻る</button>
+          <button id="backToEdit" class="custom-button">編集ページに戻る</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/skillEdit.html
+++ b/src/main/resources/templates/skillEdit.html
@@ -66,8 +66,13 @@
                         </div>
                         
                         <div class="cell delete-button">
-                            <button class="btn-delete" type="button" onclick="alert('削除は未実装です')">削除する</button>
-                        </div>
+                            <button class="btn-delete" type="button"
+                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
+                                             data-name=*{backendList[__${stat.index}__].learningName}">
+                              削除する
+                            </button>
+                          </div>
+                          
                     </div>
                 </div>
             </div>
@@ -106,8 +111,13 @@
                         </div>
 
                         <div class="cell delete-button">
-                            <button class="btn-delete" type="button" onclick="alert('削除は未実装です')">削除する</button>
-                        </div>
+                            <button class="btn-delete" type="button"
+                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
+                                             data-name=*{backendList[__${stat.index}__].learningName}">
+                              削除する
+                            </button>
+                          </div>
+                          
                     </div>
                 </div>  
             </div>
@@ -146,8 +156,13 @@
                         </div>
 
                         <div class="cell delete-button">
-                            <button class="btn-delete" type="button" onclick="alert('削除は未実装です')">削除する</button>
-                        </div>
+                            <button class="btn-delete" type="button"
+                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
+                                             data-name=*{backendList[__${stat.index}__].learningName}">
+                              削除する
+                            </button>
+                          </div>
+                          
                     </div>
                 </div>
             </div>
@@ -155,6 +170,7 @@
     </main>
 
     <div th:replace="fragments/modal/modalLearningEditSuccess :: successModal"></div>
+    <div th:replace="fragments/modal/modalDeleteSuccess :: deleteSuccessModal"></div>
     <div th:replace="~{fragments/footer :: footer}"></div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script th:src="@{/js/skillEdit.js}"></script>

--- a/src/main/resources/templates/skillEdit.html
+++ b/src/main/resources/templates/skillEdit.html
@@ -26,10 +26,10 @@
                 </option>
             </select>
         </form>
-
+    
         <form th:action="@{/learning/edit}" method="post" th:object="${form}">
-            <input type="hidden" th:field="*{targetMonth}"/>
-
+            <input type="hidden" th:field="*{targetMonth}" />
+    
             <!-- バックエンド -->
             <div class="card mb-4" th:with="categoryId=1">
                 <div class="card-header">
@@ -43,40 +43,37 @@
                         <div class="cell save-button"></div>
                         <div class="cell delete-button"></div>
                     </div>
-
+    
                     <div class="card-row" th:each="data, stat : *{backendList}">
-                        <input type="hidden" th:field="*{backendList[__${stat.index}__].id}"/>
-                        <input type="hidden" th:field="*{backendList[__${stat.index}__].learningName}"/>
-
+                        <input type="hidden" th:name="'backendList[' + ${stat.index} + '].id'" th:value="${data.id}" />
+                        <input type="hidden" th:name="'backendList[' + ${stat.index} + '].learningName'" th:value="${data.learningName}" />
+    
                         <div class="cell name">
-                            <span th:text="*{backendList[__${stat.index}__].learningName}"></span>
+                            <span th:text="${data.learningName}"></span>
                         </div>
-                        
+    
                         <div class="cell time">
-                            <input type="number" min="1" max="1440" value="1"
+                            <input type="number" min="1" max="1440"
                                 class="form-control learning-time-input"
-                                th:field="*{backendList[__${stat.index}__].learningTime}" />
+                                th:name="'backendList[' + ${stat.index} + '].learningTime'"
+                                th:value="${data.learningTime}" />
                             <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
-                        
-                                                    
-
+    
                         <div class="cell save-button">
                             <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
-                        
+    
                         <div class="cell delete-button">
                             <button class="btn-delete" type="button"
-                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
-                                             data-name=*{backendList[__${stat.index}__].learningName}">
-                              削除する
+                                    th:attr="data-id=${data.id}, data-name=${data.learningName}">
+                                削除する
                             </button>
-                          </div>
-                          
+                        </div>
                     </div>
                 </div>
             </div>
-
+    
             <!-- フロントエンド -->
             <div class="card mb-4" th:with="categoryId=2">
                 <div class="card-header">
@@ -90,38 +87,37 @@
                         <div class="cell save-button"></div>
                         <div class="cell delete-button"></div>
                     </div>
-
+    
                     <div class="card-row" th:each="data, stat : *{frontendList}">
-                        <input type="hidden" th:field="*{frontendList[__${stat.index}__].id}"/>
-                        <input type="hidden" th:field="*{frontendList[__${stat.index}__].learningName}"/>
-
+                        <input type="hidden" th:name="'frontendList[' + ${stat.index} + '].id'" th:value="${data.id}" />
+                        <input type="hidden" th:name="'frontendList[' + ${stat.index} + '].learningName'" th:value="${data.learningName}" />
+    
                         <div class="cell name">
-                            <span th:text="*{frontendList[__${stat.index}__].learningName}"></span>
+                            <span th:text="${data.learningName}"></span>
                         </div>
-                        
+    
                         <div class="cell time">
                             <input type="number" min="1" max="1440"
                                 class="form-control learning-time-input"
-                                th:field="*{frontendList[__${stat.index}__].learningTime}" />
+                                th:name="'frontendList[' + ${stat.index} + '].learningTime'"
+                                th:value="${data.learningTime}" />
                             <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
-
+    
                         <div class="cell save-button">
                             <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
-
+    
                         <div class="cell delete-button">
                             <button class="btn-delete" type="button"
-                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
-                                             data-name=*{backendList[__${stat.index}__].learningName}">
-                              削除する
+                                    th:attr="data-id=${data.id}, data-name=${data.learningName}">
+                                削除する
                             </button>
-                          </div>
-                          
+                        </div>
                     </div>
-                </div>  
+                </div>
             </div>
-
+    
             <!-- インフラ -->
             <div class="card mb-4" th:with="categoryId=3">
                 <div class="card-header">
@@ -135,39 +131,39 @@
                         <div class="cell save-button"></div>
                         <div class="cell delete-button"></div>
                     </div>
-
+    
                     <div class="card-row" th:each="data, stat : *{infraList}">
-                        <input type="hidden" th:field="*{infraList[__${stat.index}__].id}"/>
-                        <input type="hidden" th:field="*{infraList[__${stat.index}__].learningName}"/>
-
+                        <input type="hidden" th:name="'infraList[' + ${stat.index} + '].id'" th:value="${data.id}" />
+                        <input type="hidden" th:name="'infraList[' + ${stat.index} + '].learningName'" th:value="${data.learningName}" />
+    
                         <div class="cell name">
-                            <span th:text="*{infraList[__${stat.index}__].learningName}"></span>
+                            <span th:text="${data.learningName}"></span>
                         </div>
-                        
+    
                         <div class="cell time">
                             <input type="number" min="1" max="1440"
                                 class="form-control learning-time-input"
-                                th:field="*{infraList[__${stat.index}__].learningTime}" />
+                                th:name="'infraList[' + ${stat.index} + '].learningTime'"
+                                th:value="${data.learningTime}" />
                             <div class="error-message text-danger" style="min-height: 1.5em;"></div>
                         </div>
-
+    
                         <div class="cell save-button">
                             <button class="btn-save" type="button">学習時間を保存する</button>
                         </div>
-
+    
                         <div class="cell delete-button">
                             <button class="btn-delete" type="button"
-                                    th:attr="data-id=*{backendList[__${stat.index}__].id},
-                                             data-name=*{backendList[__${stat.index}__].learningName}">
-                              削除する
+                                    th:attr="data-id=${data.id}, data-name=${data.learningName}">
+                                削除する
                             </button>
-                          </div>
-                          
+                        </div>
                     </div>
                 </div>
             </div>
         </form>
     </main>
+    
 
     <div th:replace="fragments/modal/modalLearningEditSuccess :: successModal"></div>
     <div th:replace="fragments/modal/modalDeleteSuccess :: deleteSuccessModal"></div>


### PR DESCRIPTION
## 概要

- 項目一覧画面で「削除する」ボタンを押すと、該当項目を物理削除  
- 削除完了後、モーダルを表示し「編集ページに戻る」ボタンでリロード遷移  

## 実装内容

- `/learning/delete` エンドポイント追加（SkillEditController）  
- `DeleteLearningRequest` DTOを使ってIDを受け取り、Service経由で削除  
- `skillEdit.js` に削除のfetch処理とモーダル表示を実装  
- `modalDeleteSuccess.html` をフラグメント化し、モーダルに項目名を表示  

## 動作確認

- 動作確認用のユーザー情報は Slack にてご共有します

## 実装後の結果

- Slackにて動作確認動画を添付しますので、そちらをご参照ください。

### チケット
- [PRUM_ACADEMY-3614](https://prum.backlog.com/view/PRUM_ACADEMY-3615)