### PR TITLE
【テスト仕様書】NG項目の修正_バリデーションメッセージ表示の修正

### DIFF
--- a/src/main/java/com/spring/springbootapplication/controller/RegistrationController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/RegistrationController.java
@@ -25,7 +25,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class RegistrationController {
 
     private final UserService userService;
-    private final AuthenticationManager authenticationManager; // ★ 追加
+    private final AuthenticationManager authenticationManager;
 
     @GetMapping("/register")
     public String showRegistrationForm(Model model) {

--- a/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
@@ -16,6 +16,10 @@ public class UserRegistrationForm {
     private String email;
 
     @NotBlank(message = "パスワードは必ず入力してください")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$", message = "英数字8文字以上で入力してください")
-    private String password;
+    @Pattern(
+        regexp = "^$|^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$",
+        message = "英数字8文字以上で入力してください"
+    )
+private String password;
+
 }

--- a/src/main/java/com/spring/springbootapplication/entity/User.java
+++ b/src/main/java/com/spring/springbootapplication/entity/User.java
@@ -72,7 +72,6 @@ public class User implements UserDetails{
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 権限は "ROLE_USER" 固定
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
     }
 


### PR DESCRIPTION
## 概要

- テスト仕様書のNG項目の修正

## エラー詳細
- 不具合状況
  - パスワードを空にすると「英数字8文字以上で入力してください」も表示してしまう。
- 期待値
  - 「パスワードは必ず入力してください」のみ表示

## 実装内容
- UserRegistrationForm の password バリデーションを修正
  - `@Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$", message = "英数字8文字以上で入力してください")`

### チケット
- [PRUM_ACADEMY-5818](https://prum.backlog.com/view/PRUM_ACADEMY-5818)