### PR TITLE
【テスト仕様書】NG項目の修正_新規登録バリデーション修正 2

### DIFF
--- a/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
@@ -12,12 +12,11 @@ public class UserRegistrationForm {
 
     @NotBlank(message = "メールアドレスは必ず入力してください")
     @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
-    @Email(message = "メールアドレスが正しい形式ではありません")
     @Pattern(
-        regexp = "^$|^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
-        message = "メールアドレスが正しい形式ではありません" // 空は NotBlank で制御 ^$ で許容、Unicode を許容しない、ASCII のメール形式のみ許可
-)
-private String email;
+        regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+        message = "メールアドレスが正しい形式ではありません"
+    )
+    private String email;
 
     @NotBlank(message = "パスワードは必ず入力してください")
     @Size(max = 255, message = "パスワードは255文字以内で入力してください")
@@ -25,6 +24,6 @@ private String email;
         regexp = "^$|^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$",
         message = "英数字8文字以上で入力してください"
     )
-private String password;
+    private String password;
 
 }

--- a/src/main/resources/templates/registrationForm.html
+++ b/src/main/resources/templates/registrationForm.html
@@ -24,7 +24,7 @@
         <form th:action="@{/register}" method="post" th:object="${userForm}">
             <div class="mb-5">
                 <label for="name" class="form-label">氏名</label>
-                <input type="text" id="name" th:field="*{name}" class="form-control underline-input" >
+                <input type="text" id="name" th:field="*{name}" class="form-control underline-input"    >
                 <div class="text-danger" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
             </div>
 


### PR DESCRIPTION
## 概要

- テスト仕様書のNG項目の修正

## エラー詳細
- 不具合状況
  - メールアドレス255文字 → 登録不可「メールアドレスが正しい形式ではありません」と表示される
  - メールアドレス256文字 → 登録不可「メールアドレスが正しい形式ではありません」と「パスワードは255文字以内で入力してください」と表示される

- 期待値
  - メールアドレスは255文字以内で登録できる
  - パスワード256文字以上の場合「パスワードは255文字以内で入力してください」のみが表示される

## 実装内容
- フォーム DTO (UserRegistrationForm.java)
  - `@Size(max = 255, message = "パスワードは255文字以内で入力してください")`を追加
  - `Pattern`を追加、`＠Email`を削除

### チケット
- [PRUM_ACADEMY-5819](https://prum.backlog.com/view/PRUM_ACADEMY-5819)