### PR TITLE
【テスト仕様書】NG項目の修正_新規登録バリデーション修正 3

### DIFF
--- a/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
+++ b/src/main/java/com/spring/springbootapplication/dto/UserRegistrationForm.java
@@ -13,7 +13,7 @@ public class UserRegistrationForm {
     @NotBlank(message = "メールアドレスは必ず入力してください")
     @Size(max = 255, message = "メールアドレスは255文字以内で入力してください")
     @Pattern(
-        regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+        regexp = "^$|^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
         message = "メールアドレスが正しい形式ではありません"
     )
     private String email;


### PR DESCRIPTION
## 概要

- テスト仕様書のNG項目の修正

## エラー詳細
- 不具合状況
  - メールアドレス空→ 登録不可「メールアドレスは必ず入力してください」と「メールアドレスが正しい形式ではありません」と表示される

- 期待値
  - メールアドレス空の場合「メールアドレスは必ず入力してください」のみが表示される

## 実装内容
- フォーム DTO (UserRegistrationForm.java)
  - `Pattern`を`regexp = "^$|^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"`に変更

### チケット
- [PRUM_ACADEMY-5819](https://prum.backlog.com/view/PRUM_ACADEMY-5819)