### PR TITLE
【個人開発18】メンターへ動作確認を依頼する_ロゴサイズの共通化

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
   html {
     height: 100%;
   }
@@ -38,6 +40,8 @@
     justify-content: space-between;
   }
 
+
+  
   /* メイン全体 */
   .main-container {
     flex: 1;


### PR DESCRIPTION
## 概要

- メンター動作確認後のNG項目の修正

## エラー詳細

- 編集ページとTOP画面と新規登録画面で左上の「My Portfolio」の大きさが違う

## 実装内容

- style.css の先頭に `@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');` 
- TOP/skillEdit/skillNew/profileEdit でロゴの見え方を統一。