### PR TITLE
【個人開発18】メンターへ動作確認を依頼する_画像が見切れて表示される

### DIFF
--- a/src/main/resources/static/css/topPage.css
+++ b/src/main/resources/static/css/topPage.css
@@ -34,7 +34,7 @@
 .avatar-image-wrapper img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: 50%;
 }
 


### PR DESCRIPTION
## 概要

- メンター動作確認後のNG項目の修正

## 不具合の詳細

- アップロードした画像が見切れて表示されてしまう

## 実装内容

- `topPage.css`の`object-fit` を `cover` → `contain` に変更。
