### PR TITLE
feat: プロフィール画像のS3保存と旧画像互換表示を追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.hibernate.validator:hibernate-validator'
+	implementation platform("software.amazon.awssdk:bom:2.42.28")
+  implementation "software.amazon.awssdk:s3"
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
@@ -38,6 +40,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spring/springbootapplication/config/S3Config.java
+++ b/src/main/java/com/spring/springbootapplication/config/S3Config.java
@@ -1,0 +1,18 @@
+package com.spring.springbootapplication.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(@Value("${aws.region}") String region) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -3,6 +3,7 @@ package com.spring.springbootapplication.controller;
 import com.spring.springbootapplication.dto.EditProfileForm;
 import com.spring.springbootapplication.entity.User;
 import com.spring.springbootapplication.repository.UserRepository;
+import com.spring.springbootapplication.service.storage.StorageService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,29 +12,22 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.UUID;
-import java.security.Principal; // ★ 追加
+import java.security.Principal; // 認証済みユーザーの解決に使用
 
 @Controller
 @RequiredArgsConstructor
 public class ProfileEditController {
 
     private final UserRepository userRepository;
-
-    @Value("${app.upload.base:/app/uploads}")
-    private String uploadBase;
+    private final StorageService storageService;
 
     @GetMapping("/profile/edit")
-    public String showProfileEditPage(HttpSession session, Model model, Principal principal) { // ★ Principal 受け取り
+    public String showProfileEditPage(HttpSession session, Model model, Principal principal) { // S3/既存画像の表示用URLも組み立てる
         User user = (User) session.getAttribute("loggedInUser");
 
-        // ★ セッションに無ければ、認証済みユーザー(= email)から補完
+        // セッションにユーザーが無い場合は、認証情報の email から補完する
         if (user == null && principal != null) {
             user = userRepository.findByEmail(principal.getName()).orElse(null);
             if (user != null) {
@@ -50,6 +44,7 @@ public class ProfileEditController {
 
         model.addAttribute("editProfileForm", form);
         model.addAttribute("user", user);
+        model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
         return "profileEdit";
     }
 
@@ -59,7 +54,7 @@ public class ProfileEditController {
             BindingResult bindingResult,
             HttpSession session,
             Model model,
-            Principal principal) throws IOException { // ★ Principal 受け取り
+            Principal principal) throws IOException { // アップロードは StorageService に委譲する
 
         MultipartFile avatarFile = form.getAvatarFile();
 
@@ -70,7 +65,7 @@ public class ProfileEditController {
             }
         }
 
-        // ★ ユーザー解決（セッション→Principalの順）
+        // 更新対象ユーザーはセッション優先で解決し、無ければ認証情報から補完する
         User user = (User) session.getAttribute("loggedInUser");
         if (user == null && principal != null) {
             user = userRepository.findByEmail(principal.getName()).orElse(null);
@@ -84,35 +79,32 @@ public class ProfileEditController {
 
         if (bindingResult.hasErrors()) {
             model.addAttribute("user", user);
+            model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
             return "profileEdit";
         }
 
         user.setProfile(form.getProfile());
 
-        // 保存先を /app/uploads/avatars に統一（ホストは /var/app/uploads/avatars にバインド）
         if (!avatarFile.isEmpty()) {
-            String originalFilename = avatarFile.getOriginalFilename();
-            String extension = "";
-            if (originalFilename != null) {
-                int dot = originalFilename.lastIndexOf('.');
-                if (dot >= 0) {
-                    extension = originalFilename.substring(dot);
-                }
-            }
-            String newFilename = UUID.randomUUID().toString() + extension;
-
-            Path dir = Paths.get(uploadBase, "avatars");
-            Files.createDirectories(dir);
-
-            Path path = dir.resolve(newFilename);
-            Files.write(path, avatarFile.getBytes());
-
-            user.setAvatar(newFilename);
+            // 新規アップロード分は S3 に保存し、戻り値のキーを avatar カラムに保持する
+            user.setAvatar(storageService.uploadAvatar(avatarFile));
         }
 
         userRepository.save(user);
         session.setAttribute("loggedInUser", user);
 
         return "redirect:/top";
+    }
+
+    private String resolveAvatarUrl(String avatar) {
+        if (avatar == null || avatar.isBlank()) {
+            return null;
+        }
+        if (avatar.startsWith("avatars/")) {
+            // S3 移行後データはキーから公開URLを組み立てる
+            return storageService.getFileUrl(avatar);
+        }
+        // 既存データはローカル保存ファイル名として扱い、段階移行に対応する
+        return "/uploads/avatars/" + avatar;
     }
 }

--- a/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
@@ -4,8 +4,8 @@ import com.spring.springbootapplication.dto.ChartDataDto;
 import com.spring.springbootapplication.repository.LearningDataRepository;
 import com.spring.springbootapplication.entity.User;
 import com.spring.springbootapplication.service.UserService;
+import com.spring.springbootapplication.service.storage.StorageService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,11 +20,14 @@ public class SkillChartController {
 
     private final LearningDataRepository learningDataRepository;
     private final UserService userService;
+    private final StorageService storageService;
 
     @Autowired
-    public SkillChartController(LearningDataRepository learningDataRepository, UserService userService) {
+    public SkillChartController(LearningDataRepository learningDataRepository, UserService userService,
+            StorageService storageService) {
         this.learningDataRepository = learningDataRepository;
         this.userService = userService;
+        this.storageService = storageService;
     }
 
     @GetMapping("/top")
@@ -71,6 +74,7 @@ public class SkillChartController {
         model.addAttribute("months", months);
         model.addAttribute("categoryToValues", categoryToValues);
         model.addAttribute("user", user);
+        model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
 
         return "topPage";
     }
@@ -80,5 +84,15 @@ public class SkillChartController {
         return dates.stream()
                 .map(date -> date.format(formatter))
                 .toList();
+    }
+
+    private String resolveAvatarUrl(String avatar) {
+        if (avatar == null || avatar.isBlank()) {
+            return null;
+        }
+        if (avatar.startsWith("avatars/")) {
+            return storageService.getFileUrl(avatar);
+        }
+        return "/uploads/avatars/" + avatar;
     }
 }

--- a/src/main/java/com/spring/springbootapplication/service/storage/S3StorageService.java
+++ b/src/main/java/com/spring/springbootapplication/service/storage/S3StorageService.java
@@ -1,0 +1,57 @@
+package com.spring.springbootapplication.service.storage;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3StorageService implements StorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${aws.s3.base-url}")
+    private String baseUrl;
+
+    @Override
+    public String uploadAvatar(MultipartFile file) throws IOException {
+        String extension = extractExtension(file.getOriginalFilename());
+        String key = "avatars/" + UUID.randomUUID() + extension;
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+
+        return key;
+    }
+
+    @Override
+    public String getFileUrl(String key) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+        return baseUrl + "/" + key;
+    }
+
+    private String extractExtension(String fileName) {
+        if (fileName == null || !fileName.contains(".")) {
+            return "";
+        }
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/spring/springbootapplication/service/storage/StorageService.java
+++ b/src/main/java/com/spring/springbootapplication/service/storage/StorageService.java
@@ -1,0 +1,11 @@
+package com.spring.springbootapplication.service.storage;
+
+import java.io.IOException;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+    String uploadAvatar(MultipartFile file) throws IOException;
+
+    String getFileUrl(String key);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,8 @@ spring.web.resources.chain.strategy.content.paths=/**
 
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
+
+# AWS S3
+aws.region=ap-northeast-1
+aws.s3.bucket=academy-prod-avatars-prum
+aws.s3.base-url=https://academy-prod-avatars-prum.s3.ap-northeast-1.amazonaws.com

--- a/src/main/resources/templates/topPage.html
+++ b/src/main/resources/templates/topPage.html
@@ -28,14 +28,14 @@
         <div class="avatar-block">
           <div class="avatar-image-wrapper">
             <img
-              th:if="${user.avatar != null}"
-              th:src="@{/uploads/avatars/{img}(img=${user.avatar})}"
+              th:if="${avatarUrl != null}"
+              th:src="${avatarUrl}"
               alt="アバター画像"
               class="rounded-circle"
             />
 
             <img
-              th:unless="${user.avatar != null}"
+              th:unless="${avatarUrl != null}"
               th:src="@{/images/default-avatar.png}"
               alt="デフォルト画像"
               class="rounded-circle"

--- a/src/test/java/com/spring/springbootapplication/SpringbootApplicationTests.java
+++ b/src/test/java/com/spring/springbootapplication/SpringbootApplicationTests.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("local")
+@ActiveProfiles("test")
 class SpringbootApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=false
+
+spring.flyway.enabled=false


### PR DESCRIPTION
## 概要
プロフィール画像の保存先をローカルからS3へ移行するための対応を行いました。

## 変更内容
- StorageService / S3StorageService を追加
- ProfileEditController の画像保存処理をS3保存へ変更
- DBには画像URLではなくS3キーを保存する形に変更
- 既存のローカル保存画像も表示できるよう互換処理を追加
- 表示側で avatarUrl を利用するよう修正

## 確認事項
- `./gradlew test` が通ること
- 新規アップロード画像はS3経由で表示する想定
- 既存のローカル保存画像も引き続き表示できる想定

## 補足
段階移行を前提としており、既存画像は従来の `/uploads/avatars/...` 参照を残しています。