### PR TITLE
Refine avatar storage config by profile

### DIFF
--- a/src/main/java/com/spring/springbootapplication/config/S3Config.java
+++ b/src/main/java/com/spring/springbootapplication/config/S3Config.java
@@ -1,12 +1,14 @@
 package com.spring.springbootapplication.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
+@Profile("!local & !test")
 public class S3Config {
 
     @Bean

--- a/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/ProfileEditController.java
@@ -44,7 +44,7 @@ public class ProfileEditController {
 
         model.addAttribute("editProfileForm", form);
         model.addAttribute("user", user);
-        model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
+        model.addAttribute("avatarUrl", storageService.resolveAvatarUrl(user.getAvatar()));
         return "profileEdit";
     }
 
@@ -79,7 +79,7 @@ public class ProfileEditController {
 
         if (bindingResult.hasErrors()) {
             model.addAttribute("user", user);
-            model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
+            model.addAttribute("avatarUrl", storageService.resolveAvatarUrl(user.getAvatar()));
             return "profileEdit";
         }
 
@@ -94,17 +94,5 @@ public class ProfileEditController {
         session.setAttribute("loggedInUser", user);
 
         return "redirect:/top";
-    }
-
-    private String resolveAvatarUrl(String avatar) {
-        if (avatar == null || avatar.isBlank()) {
-            return null;
-        }
-        if (avatar.startsWith("avatars/")) {
-            // S3 移行後データはキーから公開URLを組み立てる
-            return storageService.getFileUrl(avatar);
-        }
-        // 既存データはローカル保存ファイル名として扱い、段階移行に対応する
-        return "/uploads/avatars/" + avatar;
     }
 }

--- a/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
+++ b/src/main/java/com/spring/springbootapplication/controller/SkillChartController.java
@@ -74,7 +74,7 @@ public class SkillChartController {
         model.addAttribute("months", months);
         model.addAttribute("categoryToValues", categoryToValues);
         model.addAttribute("user", user);
-        model.addAttribute("avatarUrl", resolveAvatarUrl(user.getAvatar()));
+        model.addAttribute("avatarUrl", storageService.resolveAvatarUrl(user.getAvatar()));
 
         return "topPage";
     }
@@ -84,15 +84,5 @@ public class SkillChartController {
         return dates.stream()
                 .map(date -> date.format(formatter))
                 .toList();
-    }
-
-    private String resolveAvatarUrl(String avatar) {
-        if (avatar == null || avatar.isBlank()) {
-            return null;
-        }
-        if (avatar.startsWith("avatars/")) {
-            return storageService.getFileUrl(avatar);
-        }
-        return "/uploads/avatars/" + avatar;
     }
 }

--- a/src/main/java/com/spring/springbootapplication/service/storage/LocalStorageService.java
+++ b/src/main/java/com/spring/springbootapplication/service/storage/LocalStorageService.java
@@ -1,6 +1,9 @@
 package com.spring.springbootapplication.service.storage;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -8,36 +11,26 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
 @Service
-@Profile("!local & !test")
-@RequiredArgsConstructor
-public class S3StorageService implements StorageService {
+@Profile({ "local", "test" })
+public class LocalStorageService implements StorageService {
 
-    private final S3Client s3Client;
+    private final Path uploadBasePath;
 
-    @Value("${aws.s3.bucket}")
-    private String bucketName;
-
-    @Value("${aws.s3.base-url}")
-    private String baseUrl;
+    public LocalStorageService(@Value("${app.upload.base:/app/uploads}") String uploadBase) {
+        this.uploadBasePath = Path.of(uploadBase);
+    }
 
     @Override
     public String uploadAvatar(MultipartFile file) throws IOException {
         String extension = extractExtension(file.getOriginalFilename());
         String key = "avatars/" + UUID.randomUUID() + extension;
+        Path destination = uploadBasePath.resolve(key);
 
-        PutObjectRequest request = PutObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .contentType(file.getContentType())
-                .build();
-
-        s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        Files.createDirectories(destination.getParent());
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, destination);
+        }
 
         return key;
     }
@@ -47,7 +40,7 @@ public class S3StorageService implements StorageService {
         if (key == null || key.isBlank()) {
             return null;
         }
-        return baseUrl + "/" + key;
+        return "/uploads/" + key;
     }
 
     private String extractExtension(String fileName) {

--- a/src/main/java/com/spring/springbootapplication/service/storage/StorageService.java
+++ b/src/main/java/com/spring/springbootapplication/service/storage/StorageService.java
@@ -8,4 +8,14 @@ public interface StorageService {
     String uploadAvatar(MultipartFile file) throws IOException;
 
     String getFileUrl(String key);
+
+    default String resolveAvatarUrl(String avatar) {
+        if (avatar == null || avatar.isBlank()) {
+            return null;
+        }
+        if (avatar.startsWith("avatars/")) {
+            return getFileUrl(avatar);
+        }
+        return "/uploads/avatars/" + avatar;
+    }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,10 +1,12 @@
 # ローカル PostgreSQL 接続設定
 spring.datasource.url=jdbc:postgresql://127.0.0.1:5432/academy-springboot-base
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:postgres}
 
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
+
+app.upload.base=./uploads
 
 spring.flyway.enabled=false
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -16,5 +16,8 @@ spring.web.resources.chain.strategy.content.paths=/**
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=5MB
 
-app.upload.base=/app/uploads
+# AWS S3
+aws.s3.bucket=academy-prod-avatars-prum
+aws.s3.base-url=https://academy-prod-avatars-prum.s3.ap-northeast-1.amazonaws.com
 
+app.upload.base=/app/uploads

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,5 +24,3 @@ spring.servlet.multipart.max-request-size=5MB
 
 # AWS S3
 aws.region=ap-northeast-1
-aws.s3.bucket=academy-prod-avatars-prum
-aws.s3.base-url=https://academy-prod-avatars-prum.s3.ap-northeast-1.amazonaws.com


### PR DESCRIPTION
## 概要
Gemini の指摘対応として、アバター保存まわりの設定と処理を整理しました。

## 修正内容
- 共通設定に直書きされていた prod 用 S3 設定を application-prod.properties へ移動
- local/test では S3 を使わずローカル保存を使うように切り替え
- StorageService に avatar URL 解決ロジックを共通化し、各コントローラーの重複実装を削除
- S3 アップロード処理を `file.getBytes()` から InputStream ベースに変更
- local 起動時に `/app` へ書き込もうとして失敗していたため、application-local.properties に `app.upload.base=./uploads` を追加

## 確認内容
- `GRADLE_USER_HOME=/Users/keisukemiura/Desktop/dev/academy-springboot-base/.gradle-home ./gradlew test`
- `local` プロファイルで起動確認
- ローカル環境でプロフィール画像アップロードが成功することを確認
